### PR TITLE
Add a 'rowwidth' optional parameter to \Row.

### DIFF
--- a/grid-system.sty
+++ b/grid-system.sty
@@ -6,10 +6,13 @@
 \RequirePackage{ifthen}
 \RequirePackage{environ,forloop}
 
-\newcommand{\gridsystem@cellwidth}[2]{#1\linewidth/#2}
+\newlength{\gridsystem@rowwidth}
+\setlength{\gridsystem@rowwidth}{\linewidth}
 
 \newlength{\gridsystem@cellsep}
 \setlength{\gridsystem@cellsep}{1.75em}
+
+\newcommand{\gridsystem@cellwidth}[2]{#1\linewidth/#2}
 
 \newlength{\gridsystem@one@cellwidth}
 
@@ -21,16 +24,17 @@
 \newcommand{\gridsystem@finishlastcell}{}
 
 \define@key{row}{cellsep}{\setlength\gridsystem@cellsep{#1}}
+\define@key{row}{rowwidth}{\setlength\gridsystem@rowwidth{#1}}
 
 %\def\convertto#1#2{\strip@pt\dimexpr #2*65536/\number\dimexpr 1#1#1}
 
-\newenvironment{row}[3][cellsep=1.75em]{%
+\newenvironment{row}[3][cellsep=1.75em,rowwidth=\linewidth]{%
 \setkeys{row}{#1}%
 \setcounter{gridsystem@cellinrow}{0}%
 \noindent%
 \newenvironment{cell}[1]{%
 	\addtocounter{gridsystem@cellinrow}{##1}%
-	\setlength{\gridsystem@one@cellwidth}{(\linewidth-\gridsystem@cellsep*(#3-1))/#2}%
+	\setlength{\gridsystem@one@cellwidth}{(\gridsystem@rowwidth-\gridsystem@cellsep*(#3-1))/#2}%
 	\begin{minipage}[t]{##1\gridsystem@one@cellwidth}%
 }{%
 	\end{minipage}%
@@ -62,13 +66,13 @@
 \newcounter{gridsystem@cellcount}
 \newcounter{gridsystem@stripecount}
 
-\newenvironment{Row}[1][cellsep=1.75em]{%
+\newenvironment{Row}[1][cellsep=1.75em,rowwidth=\linewidth]{%
 \setkeys{row}{#1}%
 \setcounter{gridsystem@cellinrow}{0}%
 \setcounter{gridsystem@stripecount}{0}%
 \noindent%
 }{%
-\setlength{\gridsystem@one@cellwidth}{(\linewidth-\gridsystem@cellsep*(\value{gridsystem@cellcount}-1))/\value{gridsystem@stripecount}}%
+\setlength{\gridsystem@one@cellwidth}{(\gridsystem@rowwidth-\gridsystem@cellsep*(\value{gridsystem@cellcount}-1))/\value{gridsystem@stripecount}}%
 % For each 1..gridsystem@cellcount
 \forloop{gridsystem@cellinrow}{0}{\value{gridsystem@cellinrow} < \value{gridsystem@cellcount}}{%
 \expandafter\begin{minipage}[t]{\dimexpr\@nameuse{gridsystem@cellwidth\arabic{gridsystem@cellinrow}}\gridsystem@one@cellwidth\relax}%

--- a/grid-system.tex
+++ b/grid-system.tex
@@ -110,13 +110,14 @@ In earlier implementations, the default interface from above would not work for 
 Each cell is created using a \texttt{minipage} environment. In future versions the will be a switch to choose either minipages or parboxes.
 
 \section{Parameters}
-There is one optional parameter for the environment \texttt{row} right now:
+There are two optional keyword parameters for the environment \texttt{row} right now:
 
 \medskip
 
 \begin{tabularx}{\linewidth}{llX}\toprule
 \textbf{Parameter} & \textbf{Default} & \textbf{Description},\\ \midrule
 cellsep & 1.75em & horizonal space between two cells.\\\bottomrule
+rowwidth & \linewidth & total horizontal space for the row.\\\bottomrule
 \end{tabularx}
 
 \section{Contribute}


### PR DESCRIPTION
The row width used to be hard-coded to `\linewidth` -- this rectifies that.
